### PR TITLE
updated virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ rad.json
 *.flf
 #Test results file
 TestResults.xml
+#Data
+raw_data
+#virtual environment
+.python-version


### PR DESCRIPTION
added python environment for this reason:

The reason why .python-version should be gitignored is because its version is too specific. Tiny versions of Python (e.g. 2.7.1 vs 2.7.2) are generally compatible with each other, so you don't want to lock down to a specific tiny version. Furthermore, many Python apps or libraries should work with a range of Python versions, not just a specific one. Using .python-version indicates that you want other developers to use an exact, specific Python version, which is usually not a good idea.
If you want to indicate the minimum Python version needed, or otherwise a version range, then I believe documenting that in a README is a more appropriate solution.

https://stackoverflow.com/questions/54315206/should-we-gitignore-the-python-version-file
